### PR TITLE
Update example4.5.js

### DIFF
--- a/exercise4/example4.5.js
+++ b/exercise4/example4.5.js
@@ -67,7 +67,7 @@ function draw_ship(ctx, radius, options) {
     );
     ctx.fill();
     ctx.beginPath();
-    ctx.arc(radius * curve1 - radius, 0, radius/50, 0, 2 * Math.PI);
+    ctx.arc(-radius * curve1, 0, radius/50, 0, 2 * Math.PI);
     ctx.fill();
   }
   ctx.restore();


### PR DESCRIPTION
Changed curve1's options arc x value
Before: (radius * curve1 - radius)
After: (-radius * curve1)
The behavior of the anchor point for the quadraticCurveTo for curve1 was not reflecting the anchor point of curve1's quadraticCurve.